### PR TITLE
Expose solver settlement tx

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -503,7 +503,7 @@ impl RunLoop {
                         .map(|(token, price)| (token.0, price.get().into()))
                         .collect(),
                     is_winner: participant.is_winner(),
-                    tx_hash: /* How do I get the txhash here? */,
+                    tx_hash: None,
                 })
                 .collect(),
         };

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -503,6 +503,7 @@ impl RunLoop {
                         .map(|(token, price)| (token.0, price.get().into()))
                         .collect(),
                     is_winner: participant.is_winner(),
+                    tx_hash: /* How do I get the txhash here? */,
                 })
                 .collect(),
         };

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -503,7 +503,7 @@ impl RunLoop {
                         .map(|(token, price)| (token.0, price.get().into()))
                         .collect(),
                     is_winner: participant.is_winner(),
-                    tx_hash: None,
+                    tx_hash: None,  // Will be filled eventually when we have tx hashes for the settlements.
                 })
                 .collect(),
         };

--- a/crates/model/src/solver_competition.rs
+++ b/crates/model/src/solver_competition.rs
@@ -54,6 +54,8 @@ pub struct SolverSettlement {
     pub orders: Vec<Order>,
     #[serde(default)]
     pub is_winner: bool,
+    #[serde(default)]
+    pub tx_hash: Option<H256>,
 }
 
 #[serde_as]

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1678,6 +1678,12 @@ components:
         isWinner:
           type: boolean
           description: whether the solution is a winner (received the right to get executed) or not
+        txHash:
+          type: string
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/TransactionHash"
+          description: Transaction hash of the settlement if executed.
     NativePriceResponse:
       description: |
         The estimated native price for the token

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1683,7 +1683,7 @@ components:
           nullable: true
           allOf:
             - $ref: "#/components/schemas/TransactionHash"
-          description: Transaction hash of the settlement if executed.
+          description: Transaction hash of the settlement if settled, null if reverted or if solution did not win.
     NativePriceResponse:
       description: |
         The estimated native price for the token

--- a/crates/orderbook/src/database/solver_competition.rs
+++ b/crates/orderbook/src/database/solver_competition.rs
@@ -1,8 +1,15 @@
 use {
-    super::Postgres, crate::solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring}, anyhow::{Context, Result}, database::{byte_array::ByteArray, solver_competition::LoadCompetition}, model::{
+    super::Postgres,
+    crate::solver_competition::{Identifier, LoadSolverCompetitionError, SolverCompetitionStoring},
+    anyhow::{Context, Result},
+    database::{byte_array::ByteArray, solver_competition::LoadCompetition},
+    model::{
         auction::AuctionId,
         solver_competition::{SolverCompetitionAPI, SolverCompetitionDB},
-    }, number::conversions::big_decimal_to_u256, primitive_types::{H160, H256, U256}, sqlx::types::JsonValue
+    },
+    number::conversions::big_decimal_to_u256,
+    primitive_types::{H160, H256, U256},
+    sqlx::types::JsonValue,
 };
 
 fn deserialize_solver_competition(
@@ -44,13 +51,23 @@ async fn load_and_deserialize_competition<'a>(
         .await
         .unwrap_or_default()
         .into_iter()
-        .map(|t| (H256(t.tx_hash.0), H160(t.solver.0), big_decimal_to_u256(&t.score).unwrap_or_default()))
+        .map(|t| {
+            (
+                H256(t.tx_hash.0),
+                H160(t.solver.0),
+                big_decimal_to_u256(&t.score).unwrap_or_default(),
+            )
+        })
         .collect();
 
     deserialize_solver_competition(
         competition.json,
         competition.id,
-        competition.tx_hashes.iter().map(|hash| H256(hash.0)).collect(),
+        competition
+            .tx_hashes
+            .iter()
+            .map(|hash| H256(hash.0))
+            .collect(),
         settlement_txs,
     )
 }


### PR DESCRIPTION
This is another attempt to map the solution to the txhash in the competition endpoint (first attempt was declined, see https://github.com/cowprotocol/services/pull/3439#pullrequestreview-2938389599 )

I personally still prefer the first attempt, because this one assumes there won't be two settlements from the same solver on the same auction with the same score, which despite the low probability, is still an ugly hack in my opinion. 

But perhaps there is a 3rd way of doing this. In any case, I can't spend more time on it. Feel free to take it or leave it.